### PR TITLE
Bugfix/issue 123/houdini otlscan path is set incorrectly

### DIFF
--- a/hooks/tk-multi-launchapp/before_app_launch.py
+++ b/hooks/tk-multi-launchapp/before_app_launch.py
@@ -79,8 +79,9 @@ class BeforeAppLaunch(sgtk.Hook):
             houdini_otls_template = tk.templates["houdini_otls"]
             otls_path = houdini_otls_template.apply_fields(current_context).replace(os.sep, '/')
 
-            # Check if HOUDINI_OTLDSCAN_PATH exists in environment, if it's empty add the default value back
-            if os.environ.get("HOUDINI_OTLDSCAN_PATH") == "":
+            # Check if HOUDINI_OTLSCAN_PATH exists in environment, if it's empty add the default value back
+            HOUDINI_OTLSCAN_PATH = os.environ.get("HOUDINI_OTLSCAN_PATH")
+            if HOUDINI_OTLSCAN_PATH is None or HOUDINI_OTLSCAN_PATH == "":
                 sgtk.util.append_path_to_env_var("HOUDINI_OTLSCAN_PATH", "@/otls")
 
             # Add the project otls path to the environment

--- a/hooks/tk-multi-launchapp/before_app_launch.py
+++ b/hooks/tk-multi-launchapp/before_app_launch.py
@@ -79,7 +79,11 @@ class BeforeAppLaunch(sgtk.Hook):
             houdini_otls_template = tk.templates["houdini_otls"]
             otls_path = houdini_otls_template.apply_fields(current_context).replace(os.sep, '/')
 
-            # Add environment
+            # Check if HOUDINI_OTLDSCAN_PATH exists in environment, if it's empty add the default value back
+            if os.environ.get("HOUDINI_OTLDSCAN_PATH") == "":
+                sgtk.util.append_path_to_env_var("HOUDINI_OTLSCAN_PATH", "@/otls")
+
+            # Add the project otls path to the environment
             sgtk.util.append_path_to_env_var("HOUDINI_OTLSCAN_PATH", otls_path)
 
             self.parent.log_info("Added otlscan path %s" % otls_path)


### PR DESCRIPTION
Closes #123. Without the default value all other otl scan paths aren't added.